### PR TITLE
HOCS-2641: refactor deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
 export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_SERVER=${KUBE_SERVER}
-
-if [[ -z ${VERSION} ]] ; then
-    export VERSION=${IMAGE_VERSION}
-fi
+export KUBE_TOKEN=${KUBE_TOKEN}
+export VERSION=${VERSION}
 
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
@@ -14,42 +13,6 @@ then
 else
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
-fi
-
-if [[ ${KUBE_NAMESPACE} == "cs-prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_WORKFLOW_CS_PROD drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_CS_PROD}
-elif [[ ${KUBE_NAMESPACE} == "wcs-prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_WORKFLOW_WCS_PROD drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_WCS_PROD}
-elif [[ ${KUBE_NAMESPACE} == "cs-qa" ]] ; then
-    echo "deploying ${VERSION} to QA namespace, using HOCS_WORKFLOW_CS_QA drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_CS_QA}
-elif [[ ${KUBE_NAMESPACE} == "wcs-qa" ]] ; then
-    echo "deploying ${VERSION} to QA namespace, using HOCS_WORKFLOW_WCS_QA drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_WCS_QA}
-elif [[ ${KUBE_NAMESPACE} == "cs-demo" ]] ; then
-    echo "deploy ${VERSION} to DEMO namespace, using HOCS_WORKFLOW_CS_DEMO drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_CS_DEMO}
-elif [[ ${KUBE_NAMESPACE} == "wcs-demo" ]] ; then
-    echo "deploy ${VERSION} to DEMO namespace, using HOCS_WORKFLOW_WCS_DEMO drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_WCS_DEMO}
-elif [[ ${KUBE_NAMESPACE} == "cs-dev" ]] ; then
-    echo "deploy ${VERSION} to DEV namespace, using HOCS_WORKFLOW_CS_DEV drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_CS_DEV}
-elif [[ ${KUBE_NAMESPACE} == "wcs-dev" ]] ; then
-    echo "deploy ${VERSION} to DEV namespace, using HOCS_WORKFLOW_WCS_DEV drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_WCS_DEV}
-elif [[ ${KUBE_NAMESPACE} == "hocs-qax" ]] ; then
-    echo "deploy ${VERSION} to qax namespace, using HOCS_WORKFLOW_QAX drone secret"
-    export KUBE_TOKEN=${HOCS_WORKFLOW_QAX}
-else
-    echo "Unable to find environment: ${ENVIRONMENT}"
-fi
-
-if [[ -z ${KUBE_TOKEN} ]] ; then
-    echo "Failed to find a value for KUBE_TOKEN - exiting"
-    exit -1
 fi
 
 cd kd


### PR DESCRIPTION
At present there is an if/else tower that handles the setting of the
KUBE_TOKEN environment variable. As we are now passing this in 
directly this is no longer needed. Alongside this, we now set the 
pipeline to fail if it returns a none 0 status code from a command.
This change also consolidates the two versions we use, `VERSION` and
`IMAGE_VERSION` down to just `VERSION`.